### PR TITLE
Make docker images easier for renovate to find

### DIFF
--- a/.env
+++ b/.env
@@ -17,22 +17,8 @@ COMPOSE_HTTP_TIMEOUT=120
 # Note that using 'consistent' can be very slow.
 CONSISTENCY=consistent
 
-# The Docker image repository of the isle-buildkit images to use.
-ISLANDORA_REPOSITORY=islandora
-
-# isle-buildkit tag
-ISLANDORA_TAG=4.0.4
-
-# The Docker image repository, to push/pull custom images from.
-# islandora.io redirects to localhost.
-REPOSITORY=islandora.io
-
-# The tag to apply to custom images.
-TAG=local
-
 # The domain at which your production site is hosted.
 DOMAIN=preserve.lehigh.edu
-SUBDOMAIN_DELIMITER=-
 ROLLOUT_DEPTH=0
 
 FEDORA_6=true

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -46,7 +46,7 @@ services:
     volumes:
       - ./conf/parry/scyllaridae.ci.yml:/app/scyllaridae.yml:r
   fits:
-    image: ${ISLANDORA_REPOSITORY}/fits:${ISLANDORA_TAG}
+    image: islandora/fits:4.0.4
     volumes:
       - ./tmp/fits:/tmp:rw
   crayfits:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,7 @@ secrets:
     file: "./secrets/JWT_PRIVATE_KEY"
 services:
   alpaca:
-    image: ${ISLANDORA_REPOSITORY}/alpaca:${ISLANDORA_TAG}
+    image: islandora/alpaca:4.0.4
     environment:
       ALPACA_MAX_REDELIVERIES: 2
       ALPACA_TRIPLESTORE_INDEXER_ENABLED: false
@@ -117,7 +117,7 @@ services:
     healthcheck:
       test: curl -s http://localhost:8080/healthcheck | grep OK
   mariadb:
-    image: ${ISLANDORA_REPOSITORY}/mariadb:${ISLANDORA_TAG}
+    image: islandora/mariadb:4.0.4
     environment:
       MYSQL_MAX_ALLOWED_PACKET: 512000000
       MYSQL_TRANSACTION_ISOLATION: READ-COMMITTED
@@ -137,7 +137,7 @@ services:
       activemq:
         condition: service_healthy
   activemq:
-    image: ${ISLANDORA_REPOSITORY}/activemq:${ISLANDORA_TAG}
+    image: islandora/activemq:4.0.4
     labels:
       traefik.enable: false
     secrets:
@@ -330,7 +330,7 @@ services:
       memcached:
         condition: service_healthy
   fcrepo:
-    image: ${ISLANDORA_REPOSITORY}/fcrepo6:${ISLANDORA_TAG}
+    image: islandora/fcrepo6:4.0.4
     environment:
       FCREPO_ALLOW_EXTERNAL_DEFAULT: "http://default/"
       FCREPO_ALLOW_EXTERNAL_DRUPAL: "https://${DOMAIN}/"
@@ -350,7 +350,7 @@ services:
       activemq:
         condition: service_started
   solr:
-    image: ${ISLANDORA_REPOSITORY}/solr:${ISLANDORA_TAG}
+    image: islandora/solr:4.0.4
     volumes:
       - solr-data:/opt/solr/server/solr/default/data:Z,rw
       - type: volume

--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -1,7 +1,6 @@
-ARG ISLANDORA_DRUPAL_TAG=4@sha256:47bff97b55216814462ec4a002da079cd7584cee62446d9a69fb2bd6e01c3279
 FROM islandora/imagemagick:alpine-3.20.2-imagemagick-7.1.1.36-r0@sha256:a1fa03a18e7e232e380d070d196dc2c0e0a8762dd385640b932e28fcacfd9b05 as imagemagick
 FROM islandora/leptonica:alpine-3.20.2-leptonica-1.84.1-r0@sha256:9e9e46a328d8b55a61a352a6b06ff175f98e40cd5773c9bf93aac58fb56b65f7 as leptonica
-FROM islandora/drupal:${ISLANDORA_DRUPAL_TAG}
+FROM islandora/drupal:4@sha256:47bff97b55216814462ec4a002da079cd7584cee62446d9a69fb2bd6e01c3279
 
 ARG \
     # renovate: datasource=repology depName=alpine_3_20/php83-pdo_sqlite
@@ -33,6 +32,5 @@ RUN --mount=type=bind,from=imagemagick,source=/packages,target=/packages \
 
 COPY --link rootfs /
 
-RUN --mount=type=cache,id=custom-drupal-composer-${TARGETARCH},sharing=locked,target=/root/.composer/cache \
-    composer install -d /var/www/drupal && \
+RUN composer install -d /var/www/drupal && \
     chown -R nginx:nginx /var/www/drupal


### PR DESCRIPTION
Now that renovate is running the upgrade show, we don't need to make convenience environment variables for docker tags. Renovate will be bumping/pinning tags so just hard code them 