### PR TITLE
Fix static site config and make lehigh pool only available from internal domain

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,7 @@ CONSISTENCY=consistent
 
 # The domain at which your production site is hosted.
 DOMAIN=preserve.lehigh.edu
+INTERNAL_DOMAIN=islandora-prod.lib.lehigh.edu
 ROLLOUT_DEPTH=0
 
 FEDORA_6=true

--- a/conf/nginx/drupal.defaults.conf
+++ b/conf/nginx/drupal.defaults.conf
@@ -1,6 +1,11 @@
 # From: https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/
 root /var/www/drupal/web;
 
+location = /healthcheck {
+    access_log off;
+    return 200;
+}
+
 location = /favicon.ico {
     log_not_found off;
     access_log off;

--- a/conf/nginx/static.conf
+++ b/conf/nginx/static.conf
@@ -9,15 +9,21 @@ server {
     listen  [::]:80;
     server_name  localhost;
 
-    location / {
-        root   /usr/share/nginx/drupal;
-        index  index.html;
-        try_files $uri/index.html $uri @fallback;
-    }
-
     location = /healthcheck {
         access_log off;
         return 200;
+    }
+
+    # if there's any query string at all, go straight to Drupal
+    error_page 418 = @drupal;
+    location / {
+        if ($args) {
+            return 418;
+        }
+
+        root   /usr/share/nginx/drupal;
+        index  index.html;
+        try_files $uri/index.html $uri @fallback;
     }
 
     location @fallback {
@@ -25,21 +31,22 @@ server {
         try_files $uri @drupal;
     }
 
-    error_page 500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
-
     location @drupal {
         # when drupal container is down
         # still allow this static config to service files on disk
         resolver 127.0.0.11 valid=30s;
         set                   $upstream "drupal";
+
         proxy_pass            http://$upstream;
         proxy_ssl_server_name on;
         proxy_set_header      Host $host;
         proxy_set_header      X-Forwarded-Proto https;
         proxy_set_header      X-Forwarded-Port 443;
         proxy_redirect        https://drupal/ https://$host/;
+    }
+
+    error_page 500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
     }
 }

--- a/conf/nginx/static.conf
+++ b/conf/nginx/static.conf
@@ -1,5 +1,5 @@
-
 real_ip_header X-Forwarded-For;
+real_ip_recursive on;
 set_real_ip_from 172.0.0.0/8;
 set_real_ip_from 128.180.1.79/32;
 set_real_ip_from 128.180.1.80/32;
@@ -26,6 +26,8 @@ server {
     }
 
     location @drupal {
+        # when drupal container is down
+        # still allow this static config to service files on disk
         resolver 127.0.0.11 valid=30s;
         set                   $upstream "drupal";
         proxy_pass            http://$upstream;

--- a/conf/nginx/static.conf
+++ b/conf/nginx/static.conf
@@ -15,6 +15,11 @@ server {
         try_files $uri/index.html $uri @fallback;
     }
 
+    location = /healthcheck {
+        access_log off;
+        return 200;
+    }
+
     location @fallback {
         root   /var/www/drupal/web;
         try_files $uri @drupal;

--- a/conf/traefik/config.tmpl
+++ b/conf/traefik/config.tmpl
@@ -49,6 +49,8 @@ http:
       middlewares:
         - redirect-sans
       tls: {}
+    # special drupal container reserved for workbench jobs
+    # which we have configured to use the internal domain
     drupal-lehigh:
       rule: Host(`{{ env "INTERNAL_DOMAIN" }}`) && !Path(`/`)
       entryPoints:
@@ -57,7 +59,7 @@ http:
       priority: 20
       service: drupal-lehigh
     drupal-static:
-      rule: Method(`GET`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
+      rule: Method(`GET`) && !PathPrefix(`/system`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`)
       entryPoints:
         - https
       tls: {}
@@ -67,7 +69,7 @@ http:
       service: drupal-static
     # if none of the other rules apply, serve drupal
     drupal:
-      rule: Host(`{{ env "DOMAIN" }}`) || Host(`islandora-prod.lib.lehigh.edu`) || Host(`islandora-test.lib.lehigh.edu`)
+      rule: Host(`{{ env "DOMAIN" }}`) || Host(`{{ env "INTERNAL_DOMAIN" }}`)
       entryPoints:
         - https
       tls: {}

--- a/conf/traefik/config.tmpl
+++ b/conf/traefik/config.tmpl
@@ -5,7 +5,7 @@ http:
       entryPoints:
         - http
       middlewares:
-        - https-redirect
+        - redirect-sans
       service: drupal
     # send prod requests for fabricator to staging
     fabricator-proxy:
@@ -57,7 +57,7 @@ http:
       priority: 20
       service: drupal-lehigh
     drupal-static:
-      rule: Method(`GET`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
+      rule: (Host(`{{ env "DOMAIN" }}`) || Host(`islandora-prod.lib.lehigh.edu`)) && Method(`GET`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
       entryPoints:
         - https
       tls: {}
@@ -153,7 +153,7 @@ http:
     redirect-sans:
       redirectRegex:
         regex: ^https?://([^/]+)(/.*)?
-        replacement: https://{{ env "DOMAIN" }}$${2}
+        replacement: https://{{ env "DOMAIN" }}${2}
         permanent: true
     rollout-strip-prefix:
       stripPrefix:

--- a/conf/traefik/config.tmpl
+++ b/conf/traefik/config.tmpl
@@ -49,27 +49,25 @@ http:
       middlewares:
         - redirect-sans
       tls: {}
-    drupal-static:
-      rule: Host(`{{ env "DOMAIN" }}`) && Method(`GET`) && !HeaderRegexp(`X-Forwarded-For`, `(.*)?(128\.180\.[0-9]{1,3}\.[0-9]{1,3})$`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
+    drupal-lehigh:
+      rule: Host(`islandora-prod.lib.lehigh.edu`) && !Path(`/`)
       entryPoints:
         - https
       tls: {}
       priority: 20
+      service: drupal-lehigh
+    drupal-static:
+      rule: Method(`GET`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
+      entryPoints:
+        - https
+      tls: {}
+      priority: 15
       middlewares:
         - captcha-protect
       service: drupal-static
-    drupal-lehigh:
-      rule: Host(`{{ env "DOMAIN" }}`) && !HeaderRegexp(`X-Forwarded-For`, `.*`)  || HeaderRegexp(`X-Forwarded-For`, `(.*)?(128\.180\.[0-9]{1,3}\.[0-9]{1,3})$`)
-      entryPoints:
-        - https
-      middlewares:
-        - captcha-protect
-      tls: {}
-      priority: 15
-      service: drupal-lehigh
     # if none of the other rules apply, serve drupal
     drupal:
-      rule: Host(`{{ env "DOMAIN" }}`) || Host(`islandora-test.lib.lehigh.edu`) || Host(`islandora-prod.lib.lehigh.edu`)
+      rule: Host(`{{ env "DOMAIN" }}`) || Host(`islandora-prod.lib.lehigh.edu`) || Host(`islandora-test.lib.lehigh.edu`)
       entryPoints:
         - https
       tls: {}

--- a/conf/traefik/config.tmpl
+++ b/conf/traefik/config.tmpl
@@ -50,14 +50,14 @@ http:
         - redirect-sans
       tls: {}
     drupal-lehigh:
-      rule: Host(`islandora-prod.lib.lehigh.edu`) && !Path(`/`)
+      rule: Host(`{{ env "INTERNAL_DOMAIN" }}`) && !Path(`/`)
       entryPoints:
         - https
       tls: {}
       priority: 20
       service: drupal-lehigh
     drupal-static:
-      rule: (Host(`{{ env "DOMAIN" }}`) || Host(`islandora-prod.lib.lehigh.edu`)) && Method(`GET`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
+      rule: Method(`GET`) && !HeaderRegexp(`Cookie`, `^.*DrupalAuth=1.*$`) && !QueryRegexp(`cache-warmer`, `.*`) && !QueryRegexp(`search_api_fulltext`, `.*`) && !QueryRegexp(`f`, `.*`) && !PathPrefix(`/system`)
       entryPoints:
         - https
       tls: {}
@@ -88,6 +88,14 @@ http:
       loadBalancer:
         servers:
           - url: http://drupal-static:80
+            weight: 99
+          - url: http://drupal:80
+            weight: 1
+        healthCheck:
+            path: /healthcheck
+            scheme: http
+            interval: 10s
+            timeout: 3s
     drupal-lehigh:
       loadBalancer:
         servers:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -365,6 +365,7 @@ services:
       --experimental.plugins.captcha-protect.version=v1.8.1
     environment:
       DOMAIN: ${DOMAIN}
+      INTERNAL_DOMAIN: ${INTERNAL_DOMAIN}
       ROLLOUT_DEPTH: ${ROLLOUT_DEPTH}
       TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY}
       TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -254,6 +254,8 @@ services:
   drupal-static:
     image: nginx:1.27.4@sha256:124b44bfc9ccd1f3cedf4b592d4d1e8bddb78b51ec2ed5056c52d3692baebc19
     restart: always
+    environment:
+      ROLLOUT: 20250408
     volumes:
       - /opt/islandora/volumes/drupal-private-files/canonical/$DOMAIN/0:/usr/share/nginx/drupal:ro
       - ./tmp/drupal/web:/var/www/drupal/web:rw

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -54,3 +54,27 @@ echo "now test when drupal container is up, but static is down"
 curl -ksf "https://${DOMAIN}/" -o /dev/null
 
 docker start lehigh-d10-drupal-static-1
+
+echo "Ensuring redirects work"
+ensure_redirect() {
+  REQUEST_URL="https://$DOMAIN"
+  if [ "$#" -eq 2 ]; then
+    REQUEST_URL=$2
+  fi
+
+  curl -svk \
+    -H "Host: $1" \
+    "${REQUEST_URL}" 2>&1 \
+  | grep -i "location: https://${DOMAIN}" > /dev/null
+}
+HOSTS=(
+  "digitalcollections.lib.lehigh.edu"
+  "preserve.lib.lehigh.edu"
+)
+for HOST in "${HOSTS[@]}"; do
+  ensure_redirect "$HOST"
+  echo "$HOST redirected to $DOMAIN"
+done
+
+ensure_redirect "$DOMAIN" "http://${DOMAIN}"
+echo "http redirected to https for ${DOMAIN}"

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -25,14 +25,12 @@ echo "testing HA setup"
 echo -e "=============================================\n\n"
 
 echo "make sure drupal is online"
-curl -ksf \
-  -H "X-Forwarded-For: 128.180.1.1" \
-  "https://${DOMAIN}/" -o /dev/null
+curl -ksf "https://${DOMAIN}/" -o /dev/null
 
 echo "bring drupal containers down"
 docker stop lehigh-d10-drupal-1
 
-sleep 5
+sleep 11
 
 echo "Send request to drupal container which should fail"
 curl -ksf "https://${DOMAIN}/?foo=bar" -o /dev/null \
@@ -47,7 +45,7 @@ docker start lehigh-d10-drupal-1
 echo "Checking site is still OK if static service is down"
 docker stop lehigh-d10-drupal-static-1
 
-sleep 10
+sleep 11
 
 curl -ksf "https://${DOMAIN}/" -o /dev/null
 

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -30,7 +30,7 @@ curl -ksf \
   "https://${DOMAIN}/" -o /dev/null
 
 echo "bring drupal containers down"
-docker stop lehigh-d10-drupal-1 lehigh-d10-drupal-lehigh-1
+docker stop lehigh-d10-drupal-1
 
 sleep 5
 
@@ -44,4 +44,13 @@ echo "make sure static site is still serving content"
 curl -ksf "https://${DOMAIN}/" -o /dev/null
 
 echo "all is well. Bring containers back up"
-docker start lehigh-d10-drupal-1 lehigh-d10-drupal-lehigh-1
+docker start lehigh-d10-drupal-1
+
+docker stop lehigh-d10-drupal-static-1
+
+sleep 5
+
+echo "now test when drupal container is up, but static is down"
+curl -ksf "https://${DOMAIN}/" -o /dev/null
+
+docker start lehigh-d10-drupal-static-1


### PR DESCRIPTION
Follow on to https://github.com/lehigh-university-libraries/isle-preserve/pull/26

Turn on `real_ip_recursive` in the static config to get the correct client IP.

And move the `drupal-lehigh` router up in priority and gate so only internal domains can access it.