### PR TITLE
Ensure paged content PDFs match the number of children they have

### DIFF
--- a/adr/0006-paged-content-pdf.md
+++ b/adr/0006-paged-content-pdf.md
@@ -24,7 +24,7 @@ So instead, we opted to add a single event in Drupal's queue, and create a queue
 
 Positive:
 
-- A conveient way to download all children images
+- A convenient way to download all children images
 - Creating the PDF as an original file allows us to leverage how the rest of our repository content is indexed. Namely, since the original file on the paged content item will have OCR created, we get all children page OCR added to our search index
 
 Negative:

--- a/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
+++ b/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
@@ -26,11 +26,14 @@ $sql = "SELECT m.entity_id AS nid, f.uri, COUNT(*) AS children
   INNER JOIN media__field_media_of mo ON m.entity_id = field_media_of_target_id
   INNER JOIN media__field_media_document d ON d.entity_id = mo.entity_id
   INNER JOIN file_managed f ON f.fid = field_media_document_target_id
-  WHERE field_model_target_id = 27
+  WHERE field_model_target_id = :tid AND n.created > :since
   GROUP BY m.entity_id
   ORDER BY m.entity_id";
-
-$items = \Drupal::database()->query($sql);
+$d_args = [
+  ':tid' => lehigh_islandora_get_tid_by_name("Paged Content", "islandora_models"),
+  ':since' => time() - 86400
+];
+$items = \Drupal::database()->query($sql, $d_args);
 
 foreach ($items as $item) {
   if (strpos($item->uri, "fedora://") !== FALSE) {

--- a/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
+++ b/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
@@ -1,0 +1,64 @@
+<?php
+
+
+use Drupal\Core\Session\UserSession;
+use Drupal\user\Entity\User;
+
+$userid = 21;
+$account = User::load($userid);
+$accountSwitcher = Drupal::service('account_switcher');
+$userSession = new UserSession([
+  'uid'   => $account->id(),
+  'name'  => $account->getDisplayName(),
+  'roles' => $account->getRoles(),
+]);
+$accountSwitcher->switchTo($userSession);
+
+$action_name = 'paged_content_created_aggregated_pdf';
+$entity_type_manager = \Drupal::entityTypeManager();
+$node_storage   = $entity_type_manager->getStorage('node');
+$action_storage = $entity_type_manager->getStorage('action');
+$action = $action_storage->load($action_name);
+
+$sql = "SELECT m.entity_id AS nid, f.uri, COUNT(*) AS children
+  FROM node__field_model m
+  INNER JOIN node__field_member_of c ON c.field_member_of_target_id = m.entity_id
+  INNER JOIN media__field_media_of mo ON m.entity_id = field_media_of_target_id
+  INNER JOIN media__field_media_document d ON d.entity_id = mo.entity_id
+  INNER JOIN file_managed f ON f.fid = field_media_document_target_id
+  WHERE field_model_target_id = 27
+  GROUP BY m.entity_id";
+
+$items = \Drupal::database()->query($sql);
+
+foreach ($items as $item) {
+  if (strpos($item->uri, "fedora://") !== FALSE) {
+    $item->uri = lehigh_islandora_fcrepo_realpath($item->uri);
+  }
+  else {
+    $item->uri = str_replace("private://", "/var/www/drupal/private", $item->uri);
+  }
+
+  if (!file_exists($item->uri) || is_dir($item->uri)) {
+    echo "Unable to find file $file\n";
+    continue;
+  }
+
+  $cmd = "pdfinfo \"$item->uri\" | awk '/Pages/ {print \$2}'";
+  $output = [];
+  exec($cmd, $output);
+  if (!empty($output[0]) && $output[0] == $item->children) {
+    echo "$item->nid has a PDF with all its children\n";
+    continue;
+  }
+
+  echo "Need new PDF for $item->nid at $item->uri. $output[0] !== $item->children\n";
+  continue;
+  try {
+    $nodes = $node_storage->loadMultiple([$item->nid]);
+  } catch (Exception $e) {
+    echo "Unable to load $item->nid\n";
+    continue;
+  }
+  $action->execute(array_values($nodes));
+}

--- a/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
+++ b/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
@@ -27,7 +27,8 @@ $sql = "SELECT m.entity_id AS nid, f.uri, COUNT(*) AS children
   INNER JOIN media__field_media_document d ON d.entity_id = mo.entity_id
   INNER JOIN file_managed f ON f.fid = field_media_document_target_id
   WHERE field_model_target_id = 27
-  GROUP BY m.entity_id";
+  GROUP BY m.entity_id
+  ORDER BY m.entity_id";
 
 $items = \Drupal::database()->query($sql);
 
@@ -36,11 +37,11 @@ foreach ($items as $item) {
     $item->uri = lehigh_islandora_fcrepo_realpath($item->uri);
   }
   else {
-    $item->uri = str_replace("private://", "/var/www/drupal/private", $item->uri);
+    $item->uri = str_replace("private://", "/var/www/drupal/private/", $item->uri);
   }
 
   if (!file_exists($item->uri) || is_dir($item->uri)) {
-    echo "Unable to find file $file\n";
+    echo "Unable to find file for $item->nid $item->uri\n";
     continue;
   }
 
@@ -48,12 +49,10 @@ foreach ($items as $item) {
   $output = [];
   exec($cmd, $output);
   if (!empty($output[0]) && $output[0] == $item->children) {
-    echo "$item->nid has a PDF with all its children\n";
     continue;
   }
 
   echo "Need new PDF for $item->nid at $item->uri. $output[0] !== $item->children\n";
-  continue;
   try {
     $nodes = $node_storage->loadMultiple([$item->nid]);
   } catch (Exception $e) {

--- a/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
+++ b/drupal/rootfs/var/www/drupal/scripts/audit/paged-content-pdf.php
@@ -21,7 +21,8 @@ $action_storage = $entity_type_manager->getStorage('action');
 $action = $action_storage->load($action_name);
 
 $sql = "SELECT m.entity_id AS nid, f.uri, COUNT(*) AS children
-  FROM node__field_model m
+  FROM node_field_data n
+  INNER JOIN node__field_model m ON m.entity_id = n.nid
   INNER JOIN node__field_member_of c ON c.field_member_of_target_id = m.entity_id
   INNER JOIN media__field_media_of mo ON m.entity_id = field_media_of_target_id
   INNER JOIN media__field_media_document d ON d.entity_id = mo.entity_id

--- a/drupal/rootfs/var/www/drupal/scripts/derivatives/hls.php
+++ b/drupal/rootfs/var/www/drupal/scripts/derivatives/hls.php
@@ -47,30 +47,7 @@ foreach($rows as $nid => $mid) {
     continue;
   }
 
-  $fedora_id = str_replace('fedora://', 'info:fedora/', $fileEntity->uri->value);
-  $ocfl_dir = lehigh_islandora_get_ocfl_dir($fedora_id);
-  $inventory = $ocfl_dir . '/extensions/0005-mutable-head/head/inventory.json';
-  if (!file_exists($inventory)) {
-    continue;
-  }
-  $inventory_json = file_get_contents($inventory);
-  $inventory = json_decode($inventory_json);
-
-  $manifests = $inventory->manifest;
-  $file = FALSE;
-  $components = explode('/', $fileEntity->uri->value);
-  $filename = array_pop($components);
-  $filename = rawurlencode($filename);
-  foreach ($manifests as $manifest) {
-    $components = explode('/', $manifest[0]);
-    $manifestFile = array_pop($components);
-    $manifestFile = urldecode($manifestFile);
-    $manifestFile = rawurlencode($manifestFile);
-    if ($manifestFile == $filename) {
-      $file = $ocfl_dir . '/' . $manifest[0];
-      break;
-    }
-  }
+  $file = lehigh_islandora_fcrepo_realpath($fileEntity->uri->value);
   if (!file_exists($file) || is_dir($file)) {
     continue;
   }

--- a/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/lehigh_islandora.module
+++ b/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/lehigh_islandora.module
@@ -790,21 +790,22 @@ function lehigh_islandora_fcrepo_realpath($uri) {
   }
 
   $inventory_json = file_get_contents($inventory);
-  $inventory = json_decode($inventory_json);
+  $inventory = json_decode($inventory_json, TRUE);
+  $head = $inventory['head'];
+  $state = $inventory['versions'][$head]['state'];
+  $manifest  = $inventory['manifest'];
 
-  $manifests = $inventory->manifest;
-  $file = FALSE;
   $components = explode('/', $uri);
   $filename = array_pop($components);
   $filename = rawurlencode($filename);
-  foreach ($manifests as $manifest) {
-    $components = explode('/', $manifest[0]);
-    $manifestFile = array_pop($components);
-    $manifestFile = urldecode($manifestFile);
-    $manifestFile = rawurlencode($manifestFile);
-    if ($manifestFile == $filename) {
-      return $ocfl_dir . '/' . $manifest[0];
+  foreach ($state as $digest => $files) {
+    if (!in_array($filename, $files)) {
+      continue;
     }
+    if (empty($manifest[$digest][0])) {
+      continue;
+    }
+    return $ocfl_dir . '/' . $manifest[$digest][0];
   }
 
   return "";

--- a/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/lehigh_islandora.module
+++ b/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/lehigh_islandora.module
@@ -777,3 +777,35 @@ function lehigh_islandora_get_vector_data(string $sentence) : string {
 
   return $response->getBody()->getContents();
 }
+
+/**
+ * Given a fedora URI, get the path on disk.
+ */
+function lehigh_islandora_fcrepo_realpath($uri) {
+  $fedora_id = str_replace('fedora://', 'info:fedora/', $uri);
+  $ocfl_dir = lehigh_islandora_get_ocfl_dir($fedora_id);
+  $inventory = $ocfl_dir . '/extensions/0005-mutable-head/head/inventory.json';
+  if (!file_exists($inventory)) {
+    return "";
+  }
+
+  $inventory_json = file_get_contents($inventory);
+  $inventory = json_decode($inventory_json);
+
+  $manifests = $inventory->manifest;
+  $file = FALSE;
+  $components = explode('/', $uri);
+  $filename = array_pop($components);
+  $filename = rawurlencode($filename);
+  foreach ($manifests as $manifest) {
+    $components = explode('/', $manifest[0]);
+    $manifestFile = array_pop($components);
+    $manifestFile = urldecode($manifestFile);
+    $manifestFile = rawurlencode($manifestFile);
+    if ($manifestFile == $filename) {
+      return $ocfl_dir . '/' . $manifest[0];
+    }
+  }
+
+  return "";
+}

--- a/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/lehigh_islandora.module
+++ b/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/lehigh_islandora.module
@@ -793,7 +793,7 @@ function lehigh_islandora_fcrepo_realpath($uri) {
   $inventory = json_decode($inventory_json, TRUE);
   $head = $inventory['head'];
   $state = $inventory['versions'][$head]['state'];
-  $manifest  = $inventory['manifest'];
+  $manifest = $inventory['manifest'];
 
   $components = explode('/', $uri);
   $filename = array_pop($components);


### PR DESCRIPTION
We noticed some of the paged content PDFs that came over from i7, as well as some ones we've generated since being on i2, do not have all the children items included in the PDF that's attached to our paged content items.

The aggregated PDF for paged content items is our trickiest derivative. Since we don't have an extent field on the parent items, it's not known how many children will get attached to a parent. Plus, the parent PDF can't get generated until all the children have their service files generated. So orchestrating this event is a challenge.

So we're adding a new script to check for and remediate these incomplete PDFs. I am going to run it to get everything backfilled, then will have this run on a cron schedule only looking at PDFs created during some rolling window, maybe last 24h.