### PR TITLE
add iiif check to test

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -142,8 +142,6 @@ services:
   cantaloupe:
     image: islandora/cantaloupe:4.1.1@sha256:7bee77179f39e9cab19522ddb009ab240c7e63adf0a3634af04103666932942c
     environment:
-      CANTALOUPE_PROCESSOR_SELECTION_STRATEGY: "ManualSelectionStrategy"
-      CANTALOUPE_PROCESSOR_MANUALSELECTIONSTRATEGY_JPG: "Java2dProcessor"
       CANTALOUPE_CACHE_SERVER_DERIVATIVE_ENABLED: "true"
       CANTALOUPE_CACHE_SERVER_DERIVATIVE: "FilesystemCache"
       CANTALOUPE_MAX_PIXELS: 0

--- a/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/tests/src/ExistingSite/PagedContentAggregatedPdfTest.php
+++ b/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/tests/src/ExistingSite/PagedContentAggregatedPdfTest.php
@@ -107,9 +107,11 @@ class PagedContentAggregatedPdfTest extends DerivativeTestBase {
 
     // Now that we loaded the manifest, the width/height of the service files
     // should be populated, so ensure that's the case.
-    $sql = "SELECT field_width_value, f.uri FROM media_field_data m
+    $sql = "SELECT field_width_value, f.uri
+      FROM media_field_data m
       INNER JOIN media__field_media_of mo ON m.mid = mo.entity_id
       INNER JOIN media__field_media_use mu ON m.mid = mu.entity_id
+      INNER JOIN media__field_width w ON m.mid = w.entity_id
       INNER JOIN media__field_media_file mf ON m.mid = mf.entity_id
       INNER JOIN file_managed f ON f.fid = field_media_file_target_id
       WHERE mu.field_media_use_target_id = :tid

--- a/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/tests/src/ExistingSite/PagedContentAggregatedPdfTest.php
+++ b/drupal/rootfs/var/www/drupal/web/modules/custom/lehigh_islandora/tests/src/ExistingSite/PagedContentAggregatedPdfTest.php
@@ -101,12 +101,12 @@ class PagedContentAggregatedPdfTest extends DerivativeTestBase {
     $this->drupalGet("/node/" . $parent->id() . "/book-manifest");
     $this->assertSession()->statusCodeEquals(200);
     $content = $this->getSession()->getPage()->getContent();
-    $json = json_decode($content, true);
+    $json = json_decode($content, TRUE);
     $this->assertNotNull($json);
     $this->assertEquals(JSON_ERROR_NONE, json_last_error());
 
-    // now that we loaded the manifest, the width/height of the service files
-    // should be populated, so ensure that's the case
+    // Now that we loaded the manifest, the width/height of the service files
+    // should be populated, so ensure that's the case.
     $sql = "SELECT field_width_value, f.uri FROM media_field_data m
       INNER JOIN media__field_media_of mo ON m.mid = mo.entity_id
       INNER JOIN media__field_media_use mu ON m.mid = mu.entity_id
@@ -128,7 +128,7 @@ class PagedContentAggregatedPdfTest extends DerivativeTestBase {
       $this->assertEquals($expected_width, $width, "File width for {$uri} does not match expected value.");
       ++$count;
     }
-    $this->assertEquals($count, count($nids)-1, "Expected the same number of service files as children nodes.");
+    $this->assertEquals($count, count($nids) - 1, "Expected the same number of service files as children nodes.");
 
     $ignoreTids = [
       lehigh_islandora_get_tid_by_name('Original File', 'islandora_media_use'),

--- a/scripts/ci/cleanup.sh
+++ b/scripts/ci/cleanup.sh
@@ -6,3 +6,4 @@ docker exec lehigh-d10-drupal-1 drush scr scripts/ci/cleanup.php
 docker exec lehigh-d10-drupal-1 rm -rf private/derivatives/
 docker exec lehigh-d10-drupal-1 rm -rf private/canonical/
 docker exec lehigh-d10-drupal-1 drush cr
+docker exec lehigh-d10-cantaloupe-1 rm -rf /data/*

--- a/scripts/maintenance/import-db.sh
+++ b/scripts/maintenance/import-db.sh
@@ -9,10 +9,6 @@ fi
 
 F="./tmp/drupal/drupal.sql"
 
-sudo touch ./drupal.sql.gz ./drupal.sql
-current_user=$(whoami)
-sudo chown "$current_user" ./drupal.sql.gz ./drupal.sql
-
 YEAR=$(date +"%Y")
 MONTH=$(date +"%m")
 DAY=$(date +"%d")
@@ -31,10 +27,10 @@ if [ -f "${F}" ]; then
 fi
 
 if [ ! -f "${F}" ]; then
+  cd ./tmp/drupal
+  rm drupal.sql.gz drupal.sql || echo "Files didn't exist"
   scp islandora-prod.lib.lehigh.edu:"/opt/islandora/backups/$YEAR/$MONTH/$DAY/drupal.sql.gz" .
   gunzip drupal.sql.gz
-  mv drupal.sql ./tmp/drupal/
 fi
-CONTAINER=$(docker container ls --format '{{.Names}}' | grep drupal)
-docker exec $CONTAINER drush sqlq --debug --file /tmp/drupal.sql
-docker exec $CONTAINER drush cr
+docker exec lehigh-d10-drupal-1 drush sqlq --debug --file /tmp/drupal.sql
+docker exec lehigh-d10-drupal-1 drush cr


### PR DESCRIPTION
a bad cantaloupe rollout caused our mirador viewer to fail. So adding a test to ensure our iiif server is working and our integration with it when generating IIIF manifests works as expected